### PR TITLE
Ability to pass in cache directory as ENV['CACHE_DIR']

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 .DS_Store
 .*.swp
 tmp
+/.idea

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,7 +5,7 @@ require 'geonames_dump'
 
 namespace :geonames_dump do
   namespace :import do
-    CACHE_DIR = Rails.root.join('db', 'geonames_cache')
+    CACHE_DIR = ENV.fetch('CACHE_DIR', Rails.root.join('db', 'geonames_cache'))
 
     GEONAMES_FEATURES_COL_NAME = [
         :geonameid, :name, :asciiname, :alternatenames, :latitude, :longitude,


### PR DESCRIPTION
If the app is running inside a Heroku/Flynn.io environment where it has no access to the underlying file system, it is helpful to pass in the cache directory as an environment variable.